### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/source-map-support": "^0.5.0",
     "@types/verror": "^1.10.3",
     "jest": "^24.9.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "source-map-support": "^0.5.13",
     "ts-jest": "^24.0.2",
     "tsc-watch": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ts-jest": "^24.0.2",
     "tsc-watch": "^2.4.0",
     "tslint": "^5.19.0",
-    "typescript": "^3.6.2"
+    "typescript": "^3.7.4"
   },
   "dependencies": {
     "better-sqlite3": "^5.4.3",

--- a/src/lsif.ts
+++ b/src/lsif.ts
@@ -191,7 +191,7 @@ export async function writeLSIF({
         .all()
     for (const result of results) {
         docs.add(result.file)
-        rangesByDoc.set(result.file, rangesByDoc.get(result.file) || new Set())
+        rangesByDoc.set(result.file, rangesByDoc.get(result.file) ?? new Set())
         const ranges = rangesByDoc.get(result.file)!
         const loc: lsp.Location = {
             uri: result.file,
@@ -237,7 +237,7 @@ export async function writeLSIF({
                 },
             },
         })
-        refsByDef.set(defstart, refsByDef.get(defstart) || new Set())
+        refsByDef.set(defstart, refsByDef.get(defstart) ?? new Set())
         const refs = refsByDef.get(defstart)!
         refs.add(refstart)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3595,10 +3595,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2833,10 +2833,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features